### PR TITLE
ADD: allow to specify device

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -45,6 +45,7 @@ my \$pb = WWW::PushBullet->new({apikey => '$PB_KEY'});
 
 \$pb->push_note(
         {
+            device_iden => '$PB_DEVICE',
             title     => "\$subject",
             body      => "\$body"
         }


### PR DESCRIPTION
Thanks for this.

PB on android has a nasty specific that notifications auto-disappear if a message is sent to "all".
This just adds the possibility to specify a device via "PB_DEVICE".
If it's not specified, the message still goes to "all".

You can get the list of devices simply with
```
#!/usr/bin/env perl
use strict;
use warnings;

use WWW::PushBullet;

my $pb = WWW::PushBullet->new({apikey => '<API_KEY>'});

my $devices = $pb->devices();

foreach my $d (@{$devices})
{
    printf "Device '%s' (%s)=> id %s\n", $d->{nickname}, $d->{model}, $d->{iden};
}
``` 